### PR TITLE
Slic3r 1.39.2-beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,14 +63,9 @@ RUN apt-get update && apt-get install -y \
   && slic3rReleaseName=$(/Slic3r/getLatestSlic3rRelease.sh name) \
   && curl -sSL ${latestSlic3r} > ${slic3rReleaseName} \
   && rm -f /Slic3r/releaseInfo.json \
-  && curl -sSL https://github.com/prusa3d/Slic3r-settings/archive/master.zip > /Slic3r/slic3r-settings.zip \
   && mkdir -p /Slic3r/slic3r-dist \
   && tar -xjf ${slic3rReleaseName} -C /Slic3r/slic3r-dist --strip-components 1 \
-  && unzip -q slic3r-settings.zip \
-  && mkdir -p /home/slic3r/.Slic3r/ \
-  && cp -a /Slic3r/Slic3r-settings-master/Slic3r\ settings\ MK2S\ MK2MM\ and\ MK3/* /home/slic3r/.Slic3r/ \
   && rm -f /Slic3r/${slic3rReleaseName} \
-  && rm -f /Slic3r/slic3r-settings.zip \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get purge -y --auto-remove jq curl ca-certificates unzip bzip2 \
   && apt-get autoclean \

--- a/getLatestSlic3rRelease.sh
+++ b/getLatestSlic3rRelease.sh
@@ -34,18 +34,18 @@ fi
 
 if [[ "$1" == "url" ]]; then
 
-  echo "$(echo ${releaseInfo} | jq -r '.assets[] | .browser_download_url | select(test("Slic3r-.+prusa3d-linux64-full.+.tar.bz2"))')"
+  echo "$(echo ${releaseInfo} | jq -r '.assets[] | .browser_download_url | select(test("Slic3rPE-.+(-\\w)?.linux64-full.+.tar.bz2"))')"
 
 elif [[ "$1" == "name" ]]; then
 
-  echo "$(echo ${releaseInfo} | jq -r '.assets[] | .name | select(test("Slic3r-.+prusa3d-linux64-full.+.tar.bz2"))')"
+  echo "$(echo ${releaseInfo} | jq -r '.assets[] | .name | select(test("Slic3rPE-.+(-\\w)?.linux64-full.+.tar.bz2"))')"
 
 elif [[ "$1" == "url_ver" ]]; then
 
-  echo $(echo ${allReleases} | jq -r ".[] | .assets[] | .browser_download_url | select(test(\"Slic3r-$VER-prusa3d-linux64-full.+.tar.bz2\"))")
+  echo $(echo ${allReleases} | jq -r ".[] | .assets[] | .browser_download_url | select(test(\"Slic3rPE-$VER(-\\w)?.linux64-full.+.tar.bz2\"))")
 
 elif [[ "$1" == "name_ver" ]]; then
 
-  echo $(echo ${allReleases} | jq -r ".[] | .assets[] | .name | select(test(\"Slic3r-$VER-prusa3d-linux64-full.+.tar.bz2\"))")
+  echo $(echo ${allReleases} | jq -r ".[] | .assets[] | .name | select(test(\"Slic3rPE-$VER(-\\w)?.linux64-full.+.tar.bz2\"))")
 
 fi


### PR DESCRIPTION
1.39.2-beta breaks with a number of conventions Prusa3d has used in the past. These commits update docker-slic3r-prusa3d to support building of the newest versions on the Docker Hub. Currently untested.