### PR TITLE
Add all the locales that Slic3r PE supports.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,25 @@ RUN apt-get update && apt-get install -y \
   libgl1-mesa-glx \
   libgl1-mesa-dri \
   xdg-utils \
+  locales \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get autoremove -y \
   && apt-get autoclean
+
+RUN sed -i \
+	-e 's/^# \(cs_CZ\.UTF-8.*\)/\1/' \
+	-e 's/^# \(de_DE\.UTF-8.*\)/\1/' \
+	-e 's/^# \(en_US\.UTF-8.*\)/\1/' \
+	-e 's/^# \(es_ES\.UTF-8.*\)/\1/' \
+	-e 's/^# \(fr_FR\.UTF-8.*\)/\1/' \
+	-e 's/^# \(it_IT\.UTF-8.*\)/\1/' \
+	-e 's/^# \(ko_KR\.UTF-8.*\)/\1/' \
+	-e 's/^# \(pl_PL\.UTF-8.*\)/\1/' \
+	-e 's/^# \(uk_UA\.UTF-8.*\)/\1/' \
+	-e 's/^# \(zh_CN\.UTF-8.*\)/\1/' \
+	/etc/locale.gen \
+  && locale-gen
 
 RUN groupadd slic3r \
   && useradd -g slic3r --create-home --home-dir /home/slic3r slic3r \


### PR DESCRIPTION
Adding the locales to the docker environment removes the warning on startup and allows users to switch to any of the supported locales.