### PR TITLE
Update image distribution: stretch->bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,12 @@
 #         # Information about where stuff is
 #         docker volume inspect slic3rSettings
 
-FROM debian:stretch
+FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y \
+  dbus-x11 \
   freeglut3 \
   libgtk2.0-dev \
-  libwxgtk3.0-dev \
   libwx-perl \
   libxmu-dev \
   libgl1-mesa-glx \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ If you're looking for a regular build of PrusaSlicer, the latest builds are avai
 
 To grab and run PrusaSlicer as a container (in GUI mode)
 
-    docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
+    docker run --net=host \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v $PWD:/Slic3r/3d:z \
     -v slic3rSettings:/home/slic3r \
     -e DISPLAY=$DISPLAY \

--- a/slic3r.sh
+++ b/slic3r.sh
@@ -2,7 +2,8 @@
 # Place this in your $PATH and chmod +x so you can run it like a regular program
 # Change paths, etc as appropriate
 
-docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
+docker run --net=host \
+-v /tmp/.X11-unix:/tmp/.X11-unix \
 -v "$PWD":/Slic3r/3d \
 -v slic3rSettings:/home/slic3r \
 -e DISPLAY="$DISPLAY" \


### PR DESCRIPTION
Changes to the image include packaging `dbus-x11` and adding `--net=host` as a parameter (required, otherwise PrusaSlicer exits before GUI launch).